### PR TITLE
feat: update home page focus messaging and fix blog UX

### DIFF
--- a/src/components/BlogCard.astro
+++ b/src/components/BlogCard.astro
@@ -14,7 +14,7 @@ const formattedDate = new Date(post.publishDate).toLocaleDateString("en-US", {
 });
 ---
 
-<article class="group text-muted-foreground">
+<article class="text-muted-foreground">
   <a href={`/blog/${post.slug}`} class="block">
     <div data-type="meta" class="type-meta-md mb-3 flex items-center gap-3">
       <time datetime={post.publishDate}>{formattedDate}</time>
@@ -25,7 +25,7 @@ const formattedDate = new Date(post.publishDate).toLocaleDateString("en-US", {
     </div>
 
     <div class="prose prose-card">
-      <h2 class="group-hover:text-primary transition-colors duration-300">
+      <h2 class="transition-colors duration-300">
         {post.title}
       </h2>
 
@@ -33,3 +33,9 @@ const formattedDate = new Date(post.publishDate).toLocaleDateString("en-US", {
     </div>
   </a>
 </article>
+
+<style>
+  article:hover .prose h2 {
+    color: var(--primary);
+  }
+</style>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -173,6 +173,8 @@ const postTopics = posts.map((p) =>
       elTopic.classList.toggle("bg-foreground", topicIsActive);
       elTopic.classList.toggle("text-background", topicIsActive);
       elTopic.classList.toggle("text-muted-foreground", !topicIsActive);
+      elTopic.classList.toggle("hover:text-foreground", !topicIsActive);
+      elTopic.classList.toggle("hover:opacity-75", topicIsActive);
 
       const anyVisible = [...postEls].some((el) => !el.hidden);
       noResults.classList.toggle("hidden", anyVisible);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,19 +32,26 @@ const jsonLd = [
 >
   <div class="prose">
     <header>
-      <p class="type-headline-sm text-foreground">
-        <em>The Supabase of A.I. Era</em>
-      </p>
+      <h2 class="!mt-0">
+        The Supabase of A.I. Era
+      </h2>
       <p class="type-body-md">
         Build AI-native backends with built-in agents, vector storage, and APIs
         — all from one modular, open-source stack.
+        We're currently directing our focus toward <a href="/lab">Unbody Lab</a>.
       </p>
     </header>
 
-    <p class="type-body-md">
-      Unbody beta is waiting list only.
-      <a href="https://forms.gle/B34fYDGxEfZk82Ad8" class="underline"
-      >Request access</a>.
-    </p>
+  </div>
+
+  <div class="mt-6">
+    <a
+      href="https://forms.gle/B34fYDGxEfZk82Ad8"
+      class="inline-flex items-center gap-3 rounded-full border border-foreground/20 px-[1.25em] py-[0.6em] hover:border-foreground/40 transition-colors duration-200"
+    >
+      <span class="type-ui-md uppercase tracking-wider text-muted-foreground">Beta</span>
+      <span class="w-px h-[0.75em] bg-foreground/20"></span>
+      <span class="type-ui-md uppercase tracking-wider text-foreground">Request access</span>
+    </a>
   </div>
 </Base>

--- a/src/pages/lab.astro
+++ b/src/pages/lab.astro
@@ -27,7 +27,7 @@ const jsonLd = {
   <Manifesto />
   <div class="mt-32 pb-12 flex flex-col items-center opacity-30">
     <div class="w-px h-24 bg-gradient-to-b from-foreground to-transparent mb-8"></div>
-    <p class="uppercase tracking-wider md:tracking-ultra whitespace-nowrap">
+    <p class="type-ui-md uppercase tracking-wider md:tracking-ultra whitespace-nowrap">
       Unbody Research Division
     </p>
   </div>


### PR DESCRIPTION
- Replace home page headline <p> with semantic <h2>
- Add Lab focus sentence inline in description paragraph
- Replace prose "Request access" link with outlined pill CTA (BETA · REQUEST ACCESS)
- Remove LAB manifesto navigator section and its inline scramble script
- Remove unused section IDs from Manifesto.astro
- Apply type-ui-md to Lab page "Unbody Research Division" label
- Fix blog topic filter: immediate highlight on click, correct hover state in active/inactive modes (light + dark)
- Fix blog card h2 hover colour (group-hover:text-primary was silently overridden by un-layered prose CSS); replace with scoped style block

Made-with: Cursor