### PR TITLE
feat: add Google Analytics tracking

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -49,6 +49,14 @@ const {
     <title>{title}</title>
     <meta name="description" content={description} />
     <SEO title={title} description={description} {...seo} />
+    <!-- Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-RZLH23GN60" is:inline></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-RZLH23GN60');
+    </script>
     <script>
     import { initThemeController } from "../scripts/theme-controller";
     initThemeController();


### PR DESCRIPTION
## Summary
- Add Google Analytics (G-RZLH23GN60) gtag snippet to Base layout
- All pages automatically tracked via shared layout

## Test plan
- [x] Verified gtag script loads locally via Network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)